### PR TITLE
chore: pin calfkit to 0.1.15 and add autonomous multi-tool-call integration test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 
 dependencies = [
-    "calfkit>=0.1.10",
+    "calfkit==0.1.15",
     "httpx>=0.27",
     "plotext>=5.3.2",
     "pydantic>=2.12.5",

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ anyio==4.12.1
     #   openai
 async-timeout==5.0.1
     # via aiokafka
-calfkit==0.1.10
+calfkit==0.1.15
     # via crypto-daytrading-arena (pyproject.toml)
 certifi==2026.2.25
     # via

--- a/tests/test_arena.py
+++ b/tests/test_arena.py
@@ -21,6 +21,7 @@ from calfkit.runners.service_client import RouterServiceClient
 from calfkit.stores.in_memory import InMemoryMessageHistoryStore
 
 from arena.models import INITIAL_CASH
+from arena.strategies import STRATEGIES
 from arena.tools import calculator, execute_trade, get_portfolio, price_book, store
 
 load_dotenv()
@@ -276,3 +277,74 @@ async def test_full_trading_session(deploy_broker):
         assert isinstance(final_msg, ModelResponse)
         assert final_msg.text is not None
         assert "btc" in final_msg.text.lower()
+
+
+@pytest.mark.asyncio
+@skip_if_no_openai_key
+async def test_autonomous_portfolio_check_and_trade(deploy_broker):
+    """Default-strategy agent checks portfolio and sells into a price spike in one turn.
+
+    Setup:
+    - Account pre-seeded with 1.0 BTC-USD at $50,010 cost basis
+    - BTC-USD live price spiked to $500,000 (10x unrealized gain)
+
+    The agent should autonomously:
+    1. Call get_portfolio — discover BTC position with massive unrealized P&L
+    2. Call execute_trade — sell some/all BTC to lock in profits
+
+    Both tool calls occur within a single client.request() invocation, proving the
+    agent makes multiple autonomous tool calls in one turn.
+    """
+    broker = deploy_broker
+    router = AgentRouterNode(
+        chat_node=ChatNode(),
+        tool_nodes=[execute_trade, get_portfolio, calculator],
+        name="autonomous_trader",
+        system_prompt=STRATEGIES["default"],
+    )
+
+    # Pre-seed the arena_router account with a BTC position
+    account = store.get_or_create(ROUTER_NAME)
+    account.positions["BTC-USD"] = 1.0
+    account.cost_basis["BTC-USD"] = 50_010.0  # avg cost $50,010 (original best_ask)
+    account.cash = INITIAL_CASH - 50_010.0  # $49,990 remaining
+
+    # Spike BTC price to $500,000 — a 10x move over cost basis
+    price_book.update({
+        "product_id": "BTC-USD",
+        "price": "500000.00",
+        "best_bid": "499500.00",
+        "best_bid_size": "5.0",
+        "best_ask": "500500.00",
+        "best_ask_size": "3.0",
+        "side": "buy",
+        "last_size": "0.5",
+        "volume_24h": "25000.0",
+        "time": "2024-01-01T12:00:00Z",
+    })
+
+    async with TestKafkaBroker(broker):
+        client = RouterServiceClient(broker, router)
+        ticker_json = (
+            '[{"product_id": "BTC-USD", "price": "500000.00", '
+            '"best_bid": "499500.00", "best_ask": "500500.00"}, '
+            '{"product_id": "SOL-USD", "price": "100.00", '
+            '"best_bid": "99.90", "best_ask": "100.10"}]'
+        )
+        response = await client.request(
+            user_prompt=(
+                "Here is the latest ticker information. You should view your "
+                "portfolio first before making any decisions to trade.\n"
+                "price = last traded price, best_bid = price you sell at, "
+                "best_ask = price you buy at.\n\n"
+                f"{ticker_json}"
+            ),
+        )
+        final_msg = await asyncio.wait_for(response.get_final_response(), timeout=45.0)
+        assert isinstance(final_msg, ModelResponse)
+
+    account = _account()
+    assert account.trade_count > 0, "Agent should have executed at least one trade"
+    pre_trade_cash = INITIAL_CASH - 50_010.0
+    assert account.cash > pre_trade_cash, "Cash should have increased from selling BTC"
+    assert account.positions.get("BTC-USD", 0) < 1.0, "Agent should have sold some/all BTC"

--- a/uv.lock
+++ b/uv.lock
@@ -107,7 +107,7 @@ wheels = [
 
 [[package]]
 name = "calfkit"
-version = "0.1.10"
+version = "0.1.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anthropic" },
@@ -124,9 +124,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uuid-utils" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ea/82/a91b126d0bb93e32af91c6377f6dcf92a9e90273c27460aba4e02dd56d3d/calfkit-0.1.10.tar.gz", hash = "sha256:4096e8fb9779fc6606de8df84c3155d6682a4f91d8b7e1b58df9c3161be695e1", size = 387058, upload-time = "2026-02-24T10:45:04.291Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/05/b1a58c5dee795a31c80114adcd2e47ac863f3f2068f7a0d36cd2f24b2f2a/calfkit-0.1.15.tar.gz", hash = "sha256:e8855b1d9e41d44171a4e0eb14ff6ea0d9e3c8d8c393d344e028d67869d647cf", size = 465881, upload-time = "2026-03-04T11:09:46.927Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/8f/3939c814a32cff356c269f0305a2107ee71c7deb7b430f76ba0d18bb5bb5/calfkit-0.1.10-py3-none-any.whl", hash = "sha256:8517e1e003f2f67a1e649184a6deff9f2f4f9c20baadb99b7f49783844343918", size = 469368, upload-time = "2026-02-24T10:45:02.272Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4b/5dcc86c9b59905eb1a916efba2405d2a42a7c44d05be707c22bc6aaa57d6/calfkit-0.1.15-py3-none-any.whl", hash = "sha256:e7e67b9bbf8473f6e3bd374a080296b778357d7c35176d0b5b8bd62d3a41263a", size = 566448, upload-time = "2026-03-04T11:09:45.08Z" },
 ]
 
 [[package]]
@@ -170,7 +170,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "calfkit", specifier = ">=0.1.10" },
+    { name = "calfkit", specifier = "==0.1.15" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "plotext", specifier = ">=5.3.2" },
     { name = "pydantic", specifier = ">=2.12.5" },


### PR DESCRIPTION
Pin calfkit dependency to latest version (0.1.15) and add a test that verifies the default-strategy agent autonomously checks its portfolio and executes a sell trade within a single request when presented with a dramatic price spike.