### PR TITLE
feat: configurable trading fees with realized P&L tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,4 +233,4 @@ For full CLI flags, config-based deployment options, and the config schema, see 
 | `arena/models.py` | `INITIAL_CASH` | `100_000.0` | Starting cash balance per agent |
 | `exchanges/coinbase.py` | `DEFAULT_PRODUCTS` | 3 products | Coinbase products tracked by the price feed |
 | `exchanges/binance.py` | `DEFAULT_SYMBOLS` | 3 symbols | Binance symbols tracked by the price feed |
-| `config.json` | `trading.fees.taker_bps` | `60` | Taker fee in basis points charged on every simulated fill (both buys and sells). `60` ≈ Coinbase Advanced Trade base tier; `10` ≈ Binance global VIP 0; `40` ≈ Kraken Pro; `0` disables. Read by both the trading tools and the price-feed connector. |
+| `config.json` | `trading.fees.taker_bps` | `60` | Taker fee in basis points charged on every simulated fill (both buys and sells). `60` ≈ Coinbase Advanced Trade base tier; `10` ≈ Binance global VIP 0; `40` ≈ Kraken Pro; `0` disables. Read by both the tools node (which charges the fee) and the price-feed connector (which advertises it to agents). |

--- a/README.md
+++ b/README.md
@@ -192,8 +192,8 @@ uv run python -m deploy.response_viewer --bootstrap-servers <broker-url>
 
 All trades and periodic portfolio snapshots are automatically saved to CSV files in the `data/` directory. Each session produces two files:
 
-- **`trades_<timestamp>.csv`** — every executed trade with price, quantity, and agent cash after settlement
-- **`snapshots_<timestamp>.csv`** — periodic portfolio state per agent, including positions, market values, and unrealized P&L
+- **`trades_<timestamp>.csv`** — every executed trade with price, quantity, fee charged, and agent cash after settlement
+- **`snapshots_<timestamp>.csv`** — periodic portfolio state per agent, including positions, market values, unrealized and realized P&L, and cumulative fees paid
 
 You can configure the snapshot interval and output directory:
 
@@ -220,8 +220,8 @@ For full CLI flags, config-based deployment options, and the config schema, see 
 
 | Tool | Description |
 |------|-------------|
-| `execute_trade` | Buy or sell a crypto product at the current market price |
-| `get_portfolio` | View cash, open positions, cost basis, P&L, and average time held |
+| `execute_trade` | Buy or sell a crypto product at the current market price. A configurable taker fee is charged on every fill (see `trading.fees.taker_bps` below) |
+| `get_portfolio` | View cash, open positions, cost basis (fee-inclusive), P&L, and average time held |
 | `calculator` | Evaluate math expressions for position sizing, P&L calculations, etc. |
 
 <br>
@@ -233,3 +233,4 @@ For full CLI flags, config-based deployment options, and the config schema, see 
 | `arena/models.py` | `INITIAL_CASH` | `100_000.0` | Starting cash balance per agent |
 | `exchanges/coinbase.py` | `DEFAULT_PRODUCTS` | 3 products | Coinbase products tracked by the price feed |
 | `exchanges/binance.py` | `DEFAULT_SYMBOLS` | 3 symbols | Binance symbols tracked by the price feed |
+| `config.json` | `trading.fees.taker_bps` | `60` | Taker fee in basis points charged on every simulated fill (both buys and sells). `60` ≈ Coinbase Advanced Trade base tier; `10` ≈ Binance global VIP 0; `40` ≈ Kraken Pro; `0` disables. Read by both the trading tools and the price-feed connector. |

--- a/arena/account_store.py
+++ b/arena/account_store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from datetime import datetime
 
+from arena.fees import FeeModel
 from arena.models import AgentAccount, TradeRecorder, TradeResult
 from arena.price_book import PriceBook
 
@@ -14,14 +15,23 @@ log = logging.getLogger(__name__)
 class AccountStore:
     """In-memory trading account store, keyed by agent_id."""
 
-    def __init__(self, price_book: PriceBook) -> None:
+    def __init__(self, price_book: PriceBook, fee_model: FeeModel | None = None) -> None:
         self._accounts: dict[str, AgentAccount] = {}
-        self._trade_log: list[tuple[str, str, str, str, float, float, float | None]] = []
+        self._trade_log: list[tuple[str, str, str, str, float, float, float, float | None]] = []
         self._price_book = price_book
         self._data_recorder: TradeRecorder | None = None
+        self._fee_model = fee_model or FeeModel()
 
     def attach_recorder(self, recorder: TradeRecorder) -> None:
         self._data_recorder = recorder
+
+    def set_fee_model(self, fee_model: FeeModel) -> None:
+        """Replace the active fee model. Used by deploy entrypoints after CLI/config resolution."""
+        self._fee_model = fee_model
+
+    @property
+    def fee_model(self) -> FeeModel:
+        return self._fee_model
 
     def get_or_create(self, agent_id: str) -> AgentAccount:
         if agent_id not in self._accounts:
@@ -38,7 +48,7 @@ class AccountStore:
         return self._price_book
 
     @property
-    def trade_log(self) -> list[tuple[str, str, str, str, float, float, float | None]]:
+    def trade_log(self) -> list[tuple[str, str, str, str, float, float, float, float | None]]:
         return self._trade_log
 
     def execute_trade(
@@ -89,18 +99,21 @@ class AccountStore:
 
         if action == "buy":
             price = float(entry["best_ask"])
-            cost = price * quantity
-            if cost > account.cash:
+            notional = price * quantity
+            cash_out, fee = self._fee_model.buy_cost(notional)
+            if cash_out > account.cash:
                 log.debug(
                     "account_store.execute_trade REJECT: insufficient cash "
-                    "need=%.2f have=%.2f agent=%s",
-                    cost, account.cash, agent_id,
+                    "need=%.2f (incl fee=%.2f) have=%.2f agent=%s",
+                    cash_out, fee, account.cash, agent_id,
                 )
                 return TradeResult(
                     False,
-                    f"Insufficient cash. Need ${cost:,.2f} but only have ${account.cash:,.2f}.",
+                    f"Insufficient cash. Need ${cash_out:,.2f} "
+                    f"(${notional:,.2f} + ${fee:,.2f} fee) "
+                    f"but only have ${account.cash:,.2f}.",
                 )
-            account.cash -= cost
+            account.cash -= cash_out
             existing_qty = account.positions.get(product_id, 0)
             now_ts = datetime.now().timestamp()
             existing_ts = account.avg_entry_ts.get(product_id, now_ts)
@@ -108,18 +121,21 @@ class AccountStore:
                 existing_qty + quantity
             )
             account.positions[product_id] = existing_qty + quantity
-            account.cost_basis[product_id] = account.cost_basis.get(product_id, 0.0) + cost
+            # Capitalize the fee into cost basis: cost basis = notional + fee = cash_out
+            account.cost_basis[product_id] = account.cost_basis.get(product_id, 0.0) + cash_out
+            account.total_fees_paid += fee
             account.trade_count += 1
-            self._record_trade(agent_id, action, product_id, quantity, price, latency)
+            self._record_trade(agent_id, action, product_id, quantity, price, fee, latency)
             log.debug(
                 "account_store.execute_trade BUY OK: agent=%s %s %s @ $%.2f "
-                "cost=$%.2f cash_after=$%.2f positions=%s trade_count=%d",
+                "notional=$%.2f fee=$%.2f cash_after=$%.2f positions=%s trade_count=%d",
                 agent_id, quantity, product_id, price,
-                cost, account.cash, dict(account.positions), account.trade_count,
+                notional, fee, account.cash, dict(account.positions), account.trade_count,
             )
             return TradeResult(
                 True,
-                f"Bought {quantity} {product_id} @ ${price:,.2f} for ${cost:,.2f}. "
+                f"Bought {quantity} {product_id} @ ${price:,.2f} for ${cash_out:,.2f} "
+                f"(${notional:,.2f} + ${fee:,.2f} fee @ {self._fee_model.taker_bps} bps). "
                 f"Cash remaining: ${account.cash:,.2f}.",
             )
 
@@ -137,10 +153,15 @@ class AccountStore:
                 f"Insufficient holdings. Want to sell {quantity} {product_id} "
                 f"but only hold {held}.",
             )
-        proceeds = price * quantity
-        account.cash += proceeds
-        # Reduce cost basis proportionally (average cost method)
+        notional = price * quantity
+        cash_in, fee = self._fee_model.sell_proceeds(notional)
+        account.cash += cash_in
+        # Reduce cost basis proportionally (average cost method). avg_cost includes
+        # the capitalized buy fee, so realized P&L nets both the entry and exit fees:
+        # (notional − sell_fee) − avg_cost·qty.
         avg_cost = account.avg_cost_per_unit(product_id)
+        account.realized_pnl += cash_in - (avg_cost * quantity)
+        account.total_fees_paid += fee
         account.cost_basis[product_id] = account.cost_basis.get(product_id, 0.0) - (
             avg_cost * quantity
         )
@@ -152,16 +173,17 @@ class AccountStore:
         else:
             account.positions[product_id] = new_qty
         account.trade_count += 1
-        self._record_trade(agent_id, action, product_id, quantity, price, latency)
+        self._record_trade(agent_id, action, product_id, quantity, price, fee, latency)
         log.debug(
             "account_store.execute_trade SELL OK: agent=%s %s %s @ $%.2f "
-            "proceeds=$%.2f cash_after=$%.2f positions=%s trade_count=%d",
+            "notional=$%.2f fee=$%.2f cash_after=$%.2f positions=%s trade_count=%d",
             agent_id, quantity, product_id, price,
-            proceeds, account.cash, dict(account.positions), account.trade_count,
+            notional, fee, account.cash, dict(account.positions), account.trade_count,
         )
         return TradeResult(
             True,
-            f"Sold {quantity} {product_id} @ ${price:,.2f} for ${proceeds:,.2f}. "
+            f"Sold {quantity} {product_id} @ ${price:,.2f} for ${cash_in:,.2f} "
+            f"(${notional:,.2f} − ${fee:,.2f} fee @ {self._fee_model.taker_bps} bps). "
             f"Cash remaining: ${account.cash:,.2f}.",
         )
 
@@ -170,12 +192,13 @@ class AccountStore:
         agent_id: str,
         action: str,
         product_id: str,
-        quantity: int,
+        quantity: float,
         price: float,
+        fee: float,
         latency: float | None = None,
     ) -> None:
         ts = datetime.now().strftime("%H:%M:%S")
-        self._trade_log.append((ts, agent_id, action, product_id, quantity, price, latency))
+        self._trade_log.append((ts, agent_id, action, product_id, quantity, price, fee, latency))
 
         if self._data_recorder is not None:
             account = self._accounts.get(agent_id)
@@ -185,6 +208,7 @@ class AccountStore:
                 product_id=product_id,
                 quantity=quantity,
                 price=price,
+                fee=fee,
                 cash_after=account.cash if account else 0.0,
                 latency=latency,
             )

--- a/arena/account_store.py
+++ b/arena/account_store.py
@@ -6,7 +6,7 @@ import logging
 from datetime import datetime
 
 from arena.fees import FeeModel
-from arena.models import AgentAccount, TradeRecorder, TradeResult
+from arena.models import AgentAccount, TradeLogEntry, TradeRecorder, TradeResult
 from arena.price_book import PriceBook
 
 log = logging.getLogger(__name__)
@@ -17,7 +17,7 @@ class AccountStore:
 
     def __init__(self, price_book: PriceBook, fee_model: FeeModel | None = None) -> None:
         self._accounts: dict[str, AgentAccount] = {}
-        self._trade_log: list[tuple[str, str, str, str, float, float, float, float | None]] = []
+        self._trade_log: list[TradeLogEntry] = []
         self._price_book = price_book
         self._data_recorder: TradeRecorder | None = None
         self._fee_model = fee_model or FeeModel()
@@ -48,7 +48,7 @@ class AccountStore:
         return self._price_book
 
     @property
-    def trade_log(self) -> list[tuple[str, str, str, str, float, float, float, float | None]]:
+    def trade_log(self) -> list[TradeLogEntry]:
         return self._trade_log
 
     def execute_trade(
@@ -198,7 +198,9 @@ class AccountStore:
         latency: float | None = None,
     ) -> None:
         ts = datetime.now().strftime("%H:%M:%S")
-        self._trade_log.append((ts, agent_id, action, product_id, quantity, price, fee, latency))
+        self._trade_log.append(
+            TradeLogEntry(ts, agent_id, action, product_id, quantity, price, fee, latency)
+        )
 
         if self._data_recorder is not None:
             account = self._accounts.get(agent_id)

--- a/arena/dashboard.py
+++ b/arena/dashboard.py
@@ -286,16 +286,16 @@ class PortfolioView:
         if not log:
             table.add_row("[dim italic]No trades yet...[/]", "", "", "", "", "", "")
         else:
-            for ts, agent_id, action, product_id, qty, price, _fee, latency in reversed(log):
-                action_style = "bold green" if action == "buy" else "bold red"
-                latency_str = f"{latency:.1f}s" if latency is not None else ""
+            for entry in reversed(log):
+                action_style = "bold green" if entry.action == "buy" else "bold red"
+                latency_str = f"{entry.latency:.1f}s" if entry.latency is not None else ""
                 table.add_row(
-                    ts,
-                    f"[{action_style}]{action.upper()}[/]",
-                    f"{qty:g}",
-                    product_id,
-                    f"${price:,.2f}",
-                    agent_id,
+                    entry.timestamp,
+                    f"[{action_style}]{entry.action.upper()}[/]",
+                    f"{entry.quantity:g}",
+                    entry.product_id,
+                    f"${entry.price:,.2f}",
+                    entry.agent_id,
                     latency_str,
                 )
 

--- a/arena/dashboard.py
+++ b/arena/dashboard.py
@@ -165,11 +165,16 @@ class PortfolioView:
         )
         for rank, (agent_id, account) in enumerate(sorted_accounts, start=1):
             value = account.portfolio_value(price_book)
+            realized = account.realized_pnl
+            realized_color = "green" if realized >= 0 else "red"
+            realized_sign = "+" if realized >= 0 else ""
             card = Panel(
                 Text.from_markup(
                     f"[magenta]Total Value:[/] ${value:,.2f}\n"
                     f"[yellow]Positions:[/] {len(account.positions)}  "
-                    f"[cyan]Trades:[/] {account.trade_count}"
+                    f"[cyan]Trades:[/] {account.trade_count}\n"
+                    f"[{realized_color}]Realized P&L:[/] {realized_sign}${realized:,.2f}  "
+                    f"[dim]Fees paid:[/] ${account.total_fees_paid:,.2f}"
                 ),
                 title=f"[bold]#{rank} {agent_id}[/]",
                 border_style="cyan",
@@ -281,7 +286,7 @@ class PortfolioView:
         if not log:
             table.add_row("[dim italic]No trades yet...[/]", "", "", "", "", "", "")
         else:
-            for ts, agent_id, action, product_id, qty, price, latency in reversed(log):
+            for ts, agent_id, action, product_id, qty, price, _fee, latency in reversed(log):
                 action_style = "bold green" if action == "buy" else "bold red"
                 latency_str = f"{latency:.1f}s" if latency is not None else ""
                 table.add_row(

--- a/arena/fees.py
+++ b/arena/fees.py
@@ -1,0 +1,41 @@
+"""Trading fee model.
+
+All simulated fills cross the spread (buys at best_ask, sells at best_bid),
+so only the taker rate is applied. Quoted in basis points (bps): 1 bps = 0.01%.
+Default 60 bps matches Coinbase Advanced Trade's base-tier taker rate; override
+per-deployment via config.json (`trading.fees.taker_bps`), which is the single
+source of truth read by both the trading tools and the price-feed connector.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FeeModel:
+    taker_bps: int = 60
+
+    def __post_init__(self) -> None:
+        if self.taker_bps < 0:
+            raise ValueError(f"taker_bps must be non-negative, got {self.taker_bps}")
+
+    @property
+    def taker_rate(self) -> float:
+        return self.taker_bps / 10_000.0
+
+    def buy_cost(self, notional: float) -> tuple[float, float]:
+        """For a buy of size `notional` (price * qty), return (cash_out, fee).
+
+        The fee is capitalized into cost basis: cash_out = notional + fee.
+        """
+        fee = notional * self.taker_rate
+        return notional + fee, fee
+
+    def sell_proceeds(self, notional: float) -> tuple[float, float]:
+        """For a sell of size `notional` (price * qty), return (cash_in, fee).
+
+        The fee is deducted from proceeds: cash_in = notional - fee.
+        """
+        fee = notional * self.taker_rate
+        return notional - fee, fee

--- a/arena/fees.py
+++ b/arena/fees.py
@@ -2,40 +2,67 @@
 
 All simulated fills cross the spread (buys at best_ask, sells at best_bid),
 so only the taker rate is applied. Quoted in basis points (bps): 1 bps = 0.01%.
-Default 60 bps matches Coinbase Advanced Trade's base-tier taker rate; override
-per-deployment via config.json (`trading.fees.taker_bps`), which is the single
-source of truth read by both the trading tools and the price-feed connector.
+
+The default of 60 bps matches Coinbase Advanced Trade's base-tier taker rate.
+The rate is configured via config.json (`trading.fees.taker_bps`), read
+independently by the tools-node entrypoint (which charges the fee) and the
+price-feed connector (which advertises it to agents).
+
+`taker_bps` is an integer: every documented venue preset (Coinbase 60, Binance
+VIP 0 = 10, Kraken Pro = 40) is a whole number of basis points. Fractional-bps
+rates (e.g. Binance's 7.5 bps BNB discount) are intentionally out of scope.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import NamedTuple
+
+# Single canonical default, referenced by FeeModel and config.FeeConfig so the
+# "60 bps" default lives in exactly one place.
+DEFAULT_TAKER_BPS = 60
+# Upper guard against fat-fingered config (1000 bps = 10%); a higher rate is
+# almost certainly a misconfiguration rather than a real venue fee.
+MAX_TAKER_BPS = 1000
+
+
+class Fill(NamedTuple):
+    """Outcome of applying fees to one fill.
+
+    `cash` is the cash leaving the account on a buy (cash_out) or entering it on
+    a sell (cash_in); `fee` is the taker fee charged on the fill.
+    """
+
+    cash: float
+    fee: float
 
 
 @dataclass(frozen=True)
 class FeeModel:
-    taker_bps: int = 60
+    taker_bps: int = DEFAULT_TAKER_BPS
 
     def __post_init__(self) -> None:
-        if self.taker_bps < 0:
-            raise ValueError(f"taker_bps must be non-negative, got {self.taker_bps}")
+        if not 0 <= self.taker_bps <= MAX_TAKER_BPS:
+            raise ValueError(
+                f"taker_bps must be between 0 and {MAX_TAKER_BPS}, got {self.taker_bps}"
+            )
 
     @property
     def taker_rate(self) -> float:
         return self.taker_bps / 10_000.0
 
-    def buy_cost(self, notional: float) -> tuple[float, float]:
-        """For a buy of size `notional` (price * qty), return (cash_out, fee).
+    def buy_cost(self, notional: float) -> Fill:
+        """For a buy of size `notional` (price * qty), return the cash out and fee.
 
         The fee is capitalized into cost basis: cash_out = notional + fee.
         """
         fee = notional * self.taker_rate
-        return notional + fee, fee
+        return Fill(notional + fee, fee)
 
-    def sell_proceeds(self, notional: float) -> tuple[float, float]:
-        """For a sell of size `notional` (price * qty), return (cash_in, fee).
+    def sell_proceeds(self, notional: float) -> Fill:
+        """For a sell of size `notional` (price * qty), return the cash in and fee.
 
         The fee is deducted from proceeds: cash_in = notional - fee.
         """
         fee = notional * self.taker_rate
-        return notional - fee, fee
+        return Fill(notional - fee, fee)

--- a/arena/fees.py
+++ b/arena/fees.py
@@ -66,3 +66,14 @@ class FeeModel:
         """
         fee = notional * self.taker_rate
         return Fill(notional - fee, fee)
+
+    def disclosure_prompt(self) -> str:
+        """Agent-facing description of the fee, injected into the ticker prompt."""
+        if self.taker_bps == 0:
+            return "Trading is fee-free in this deployment."
+        return (
+            f"A taker fee of {self.taker_bps} bps "
+            f"({self.taker_bps / 100:.2f}%) is charged on every fill "
+            "(both buys and sells). Factor this into your sizing and P&L targets — "
+            f"a round-trip costs {2 * self.taker_bps} bps."
+        )

--- a/arena/models.py
+++ b/arena/models.py
@@ -27,6 +27,12 @@ class AgentAccount:
     # Weighted-average entry timestamp (Unix epoch) per position
     avg_entry_ts: dict[str, float] = field(default_factory=dict)
     trade_count: int = 0
+    # Cumulative taker fees paid across all fills (buys + sells).
+    total_fees_paid: float = 0.0
+    # Realized P&L from closed quantity, net of both entry and exit fees.
+    # Buy fees enter via the capitalized cost basis; sell fees are deducted
+    # from proceeds — so this figure already reflects the full round-trip cost.
+    realized_pnl: float = 0.0
 
     def portfolio_value(self, price_book: PriceBook) -> float:
         """Total value: cash + mark-to-market of all positions using live prices."""
@@ -57,6 +63,7 @@ class TradeRecorder(typing.Protocol):
         product_id: str,
         quantity: float,
         price: float,
+        fee: float,
         cash_after: float,
         latency: float | None,
     ) -> None: ...

--- a/arena/models.py
+++ b/arena/models.py
@@ -51,6 +51,22 @@ class AgentAccount:
         return self.cost_basis.get(product_id, 0.0) / qty
 
 
+# ── Trade log ────────────────────────────────────────────────────
+
+
+class TradeLogEntry(typing.NamedTuple):
+    """One row of the in-memory trade log feeding the dashboard's recent-trades panel."""
+
+    timestamp: str
+    agent_id: str
+    action: str
+    product_id: str
+    quantity: float
+    price: float
+    fee: float
+    latency: float | None
+
+
 # ── Trade recorder protocol ──────────────────────────────────────
 
 

--- a/arena/recorder.py
+++ b/arena/recorder.py
@@ -29,6 +29,7 @@ class TradeRow(BaseModel):
     quantity: float
     price: float
     total_value: float
+    fee: float
     cash_after: float
     latency: float | None
 
@@ -45,6 +46,8 @@ class SnapshotRow(BaseModel):
     unrealized_pnl: float
     portfolio_value: float
     trade_count: int
+    realized_pnl: float
+    total_fees_paid: float
 
 
 # ── DataRecorder ─────────────────────────────────────────────────
@@ -91,6 +94,7 @@ class DataRecorder:
         product_id: str,
         quantity: float,
         price: float,
+        fee: float,
         cash_after: float,
         latency: float | None,
     ) -> None:
@@ -102,6 +106,7 @@ class DataRecorder:
             quantity=quantity,
             price=price,
             total_value=price * quantity,
+            fee=fee,
             cash_after=cash_after,
             latency=latency,
         )
@@ -134,6 +139,8 @@ class DataRecorder:
                     unrealized_pnl=0.0,
                     portfolio_value=portfolio_val,
                     trade_count=account.trade_count,
+                    realized_pnl=account.realized_pnl,
+                    total_fees_paid=account.total_fees_paid,
                 )
                 self._snapshots_writer.writerow(row.model_dump())
             else:
@@ -156,6 +163,8 @@ class DataRecorder:
                         unrealized_pnl=unrealized_pnl,
                         portfolio_value=portfolio_val,
                         trade_count=account.trade_count,
+                        realized_pnl=account.realized_pnl,
+                        total_fees_paid=account.total_fees_paid,
                     )
                     self._snapshots_writer.writerow(row.model_dump())
 

--- a/arena/tools.py
+++ b/arena/tools.py
@@ -119,13 +119,19 @@ def execute_trade(ctx: ToolContext, product_id: str, quantity: float, action: st
     Buys execute at the best ask price, sells at the best bid.
     Fractional share trading is allowed, but only to one decimal place (e.g., 0.5, 1.2).
 
+    A taker fee (set by the deployment) is charged on every fill and applies to both
+    buys and sells. Buys cost: notional + fee. Sells proceed: notional − fee. The fee
+    rate in effect is reported alongside each ticker update you receive. Size positions
+    so expected returns exceed the round-trip fee, or you will lose money on flat markets.
+
     Args:
         product_id: Trading pair (e.g., BTC-USD, FARTCOIN-USD, SOL-USD)
         quantity: Number of units to trade (positive, up to 1 decimal place)
         action: 'buy' or 'sell'
 
     Returns:
-        Trade confirmation with execution price and remaining cash, or an error message
+        Trade confirmation with execution price, fee charged, and remaining cash,
+        or an error message
     """
     log.debug(
         "execute_trade ENTER: agent=%s product=%s qty=%s action=%s tool_call_id=%s",

--- a/config.example.json
+++ b/config.example.json
@@ -41,6 +41,10 @@
       "BTC-USD",
       "SOL-USD",
       "FARTCOIN-USD"
-    ]
+    ],
+    "fees": {
+      "_comment": "Taker fee in basis points (1 bps = 0.01%). 60 = Coinbase Advanced Trade base tier. Set to 10 for Binance global VIP 0, or 0 to disable.",
+      "taker_bps": 60
+    }
   }
 }

--- a/config.py
+++ b/config.py
@@ -59,6 +59,21 @@ class AgentConfig(BaseModel):
     strategy: str = Field("default", description="Trading strategy (selects system prompt).")
 
 
+class FeeConfig(BaseModel):
+    """Trading fee configuration. All simulated fills cross the spread, so only
+    the taker rate is applied. Expressed in basis points (1 bps = 0.01%).
+
+    Default 60 bps matches Coinbase Advanced Trade's base-tier taker rate. Set to
+    10 for Binance global (VIP 0), 40 for Kraken Pro, or 0 to disable.
+    """
+
+    taker_bps: int = Field(
+        60,
+        description="Taker fee in basis points (60 bps = 0.60%). 0 disables fees.",
+        ge=0,
+    )
+
+
 class TradingConfig(BaseModel):
     """Trading-related configuration."""
 
@@ -72,6 +87,10 @@ class TradingConfig(BaseModel):
     coinbase_products: list[str] = Field(
         default_factory=lambda: DEFAULT_COINBASE_PRODUCTS.copy(),
         description="Coinbase product IDs to subscribe to.",
+    )
+    fees: FeeConfig = Field(
+        default_factory=FeeConfig,
+        description="Trading fees applied to every simulated fill.",
     )
 
 

--- a/config.py
+++ b/config.py
@@ -7,6 +7,7 @@ API keys can be embedded directly or referenced via env vars using ${VAR_NAME} s
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 from pathlib import Path
@@ -186,6 +187,26 @@ def load_config(config_path: Path | str | None = None) -> ArenaConfig:
     data = resolve_env_vars(data)
 
     return ArenaConfig.model_validate(data)
+
+
+def load_config_strict(config_path: Path | str | None = None) -> ArenaConfig:
+    """Load configuration, failing loud on an invalid file.
+
+    `load_config` already returns defaults when the file is absent, so any
+    exception here means the file exists but is broken (bad JSON, an unset
+    `${ENV_VAR}` reference, or an out-of-range value). A wrong fee rate would
+    invalidate the whole run and silently desync the fee charged on fills from
+    the fee advertised to agents, so log at ERROR and re-raise rather than
+    guessing a default. Used by the deploy entrypoints that resolve the fee.
+    """
+    try:
+        return load_config(config_path)
+    except Exception:
+        logging.getLogger(__name__).error(
+            "Failed to load config from %s; refusing to start with an unknown fee "
+            "rate. Fix the config, or remove it to use defaults.", config_path,
+        )
+        raise
 
 
 def get_default_symbols(exchange: str = "binance") -> list[str]:

--- a/config.py
+++ b/config.py
@@ -16,6 +16,8 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
+from arena.fees import DEFAULT_TAKER_BPS, MAX_TAKER_BPS
+
 DEFAULT_CONFIG_PATH = Path("config.json")
 
 # Default coin pairs
@@ -68,9 +70,10 @@ class FeeConfig(BaseModel):
     """
 
     taker_bps: int = Field(
-        60,
+        DEFAULT_TAKER_BPS,
         description="Taker fee in basis points (60 bps = 0.60%). 0 disables fees.",
         ge=0,
+        le=MAX_TAKER_BPS,
     )
 
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -111,9 +111,27 @@
           },
           "title": "Coinbase Products",
           "type": "array"
+        },
+        "fees": {
+          "$ref": "#/$defs/FeeConfig",
+          "description": "Trading fees applied to every simulated fill."
         }
       },
       "title": "TradingConfig",
+      "type": "object"
+    },
+    "FeeConfig": {
+      "description": "Trading fee configuration. Only the taker rate applies because all simulated fills cross the spread.",
+      "properties": {
+        "taker_bps": {
+          "default": 60,
+          "description": "Taker fee in basis points (60 bps = 0.60%). 0 disables fees.",
+          "minimum": 0,
+          "title": "Taker Bps",
+          "type": "integer"
+        }
+      },
+      "title": "FeeConfig",
       "type": "object"
     }
   },

--- a/deploy/tools_and_dashboard.py
+++ b/deploy/tools_and_dashboard.py
@@ -80,12 +80,17 @@ async def main():
 
     # Resolve the taker fee from config — the single source of truth shared with
     # the price-feed connector, so the fee charged here always matches the fee the
-    # connector advertises to agents in the ticker prompt.
+    # connector advertises to agents. load_config returns defaults when config.json
+    # is absent; if it raises, the file exists but is invalid — fail loud rather than
+    # silently charging the wrong fee.
     try:
         taker_bps = load_config(args.config).trading.fees.taker_bps
-    except Exception as e:
-        logging.getLogger(__name__).debug("Config not loaded, using default fee: %s", e)
-        taker_bps = FeeModel().taker_bps
+    except Exception:
+        logging.getLogger(__name__).error(
+            "Failed to load fee config from %s; refusing to start with an unknown fee "
+            "rate. Fix the config, or remove it to use defaults.", args.config,
+        )
+        raise
     store.set_fee_model(FeeModel(taker_bps=taker_bps))
     print(f"Trading fee: {taker_bps} bps ({taker_bps / 100:.2f}% taker) applied to every fill")
 

--- a/deploy/tools_and_dashboard.py
+++ b/deploy/tools_and_dashboard.py
@@ -10,6 +10,7 @@ from exchanges import (
     PRICE_TOPIC,
     TickerMessage,
 )
+from arena.fees import FeeModel
 from arena.tools import (
     calculator,
     execute_trade,
@@ -18,6 +19,7 @@ from arena.tools import (
     store,
     view,
 )
+from config import load_config
 
 # Tools & Price Feed — Deploys trading tool workers and subscribes
 # to the Kafka price topic published by the connector.
@@ -55,6 +57,11 @@ def parse_args():
         default="./data",
         help="Output directory for CSV data files",
     )
+    parser.add_argument(
+        "--config",
+        default="config.json",
+        help="Path to config file (default: config.json).",
+    )
     return parser.parse_args()
 
 
@@ -70,6 +77,17 @@ async def main():
     print("=" * 50)
     print("Tools & Price Feed Deployment")
     print("=" * 50)
+
+    # Resolve the taker fee from config — the single source of truth shared with
+    # the price-feed connector, so the fee charged here always matches the fee the
+    # connector advertises to agents in the ticker prompt.
+    try:
+        taker_bps = load_config(args.config).trading.fees.taker_bps
+    except Exception as e:
+        logging.getLogger(__name__).debug("Config not loaded, using default fee: %s", e)
+        taker_bps = FeeModel().taker_bps
+    store.set_fee_model(FeeModel(taker_bps=taker_bps))
+    print(f"Trading fee: {taker_bps} bps ({taker_bps / 100:.2f}% taker) applied to every fill")
 
     print(f"\nConnecting to Kafka broker at {args.bootstrap_servers}...")
     client = Client.connect(args.bootstrap_servers)

--- a/deploy/tools_and_dashboard.py
+++ b/deploy/tools_and_dashboard.py
@@ -19,7 +19,7 @@ from arena.tools import (
     store,
     view,
 )
-from config import load_config
+from config import load_config_strict
 
 # Tools & Price Feed — Deploys trading tool workers and subscribes
 # to the Kafka price topic published by the connector.
@@ -80,17 +80,8 @@ async def main():
 
     # Resolve the taker fee from config — the single source of truth shared with
     # the price-feed connector, so the fee charged here always matches the fee the
-    # connector advertises to agents. load_config returns defaults when config.json
-    # is absent; if it raises, the file exists but is invalid — fail loud rather than
-    # silently charging the wrong fee.
-    try:
-        taker_bps = load_config(args.config).trading.fees.taker_bps
-    except Exception:
-        logging.getLogger(__name__).error(
-            "Failed to load fee config from %s; refusing to start with an unknown fee "
-            "rate. Fix the config, or remove it to use defaults.", args.config,
-        )
-        raise
+    # connector advertises to agents.
+    taker_bps = load_config_strict(args.config).trading.fees.taker_bps
     store.set_fee_model(FeeModel(taker_bps=taker_bps))
     print(f"Trading fee: {taker_bps} bps ({taker_bps / 100:.2f}% taker) applied to every fill")
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -6,6 +6,7 @@ The trading arena supports a JSON configuration file (`config.json` by default) 
 - Multiple LLM providers (OpenAI, OpenRouter)
 - Multiple agents with different providers/models/strategies
 - Exchange selection and trading pairs for Binance and Coinbase
+- The taker fee charged on every simulated fill (`trading.fees.taker_bps`)
 
 To get started, copy the example and fill in your API keys:
 ```bash
@@ -51,7 +52,8 @@ For the full config schema with all fields, types, and defaults, see [`config.sc
   "trading": {
     "exchange": "coinbase",
     "binance_symbols": ["BTCUSDT", "SOLUSDT", "FARTCOINUSDT"],
-    "coinbase_products": ["BTC-USD", "SOL-USD", "FARTCOIN-USD"]
+    "coinbase_products": ["BTC-USD", "SOL-USD", "FARTCOIN-USD"],
+    "fees": { "taker_bps": 60 }
   }
 }
 ```
@@ -151,4 +153,48 @@ uv run python -m exchanges.coinbase --bootstrap-servers localhost:9092
 uv run python -m exchanges.coinbase \
     --bootstrap-servers localhost:9092 \
     --products BTC-USD ETH-USD SOL-USD
+```
+
+---
+
+## deploy/tools_and_dashboard.py
+
+Deploy trading tools, the price-feed subscriber, and the live dashboard.
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--bootstrap-servers` | Yes | — | Kafka broker address |
+| `--config` | No | `config.json` | Path to config file |
+| `--snapshot-interval` | No | `600` | Seconds between portfolio snapshots (`0` disables CSV recording) |
+| `--data-dir` | No | `./data` | Output directory for CSV data files |
+
+The taker fee is configured by `trading.fees.taker_bps` in `config.json` — the
+single source of truth read by both this tools node and the price-feed connector,
+so the fee charged on fills always matches the fee the connector advertises to
+agents. The fee applies to both buys and sells (buys pay notional + fee, sells
+receive notional − fee, and buy fees capitalize into cost basis).
+
+> **Changing the fee:** both processes read `taker_bps` once at startup, so after
+> editing `config.json` you must restart **both** the exchange connector and this
+> tools-and-dashboard process. Restarting only one leaves the charged fee and the
+> fee advertised to agents out of sync.
+
+Realistic values:
+
+| Exchange | Suggested `taker_bps` |
+|---|---|
+| Coinbase Advanced Trade base tier | `60` (default) |
+| Binance global (VIP 0) | `10` |
+| Binance.US | `60` |
+| Kraken Pro | `40` |
+| Disable fees | `0` |
+
+**Examples:**
+```bash
+# Uses trading.fees.taker_bps from config.json (default 60 bps)
+uv run python -m deploy.tools_and_dashboard --bootstrap-servers localhost:9092
+
+# Point at an alternate config (e.g. one with taker_bps: 10 for Binance VIP 0)
+uv run python -m deploy.tools_and_dashboard \
+    --bootstrap-servers localhost:9092 --config config.binance.json
 ```

--- a/docs/csv-data-recording.md
+++ b/docs/csv-data-recording.md
@@ -38,16 +38,17 @@ One row is written per executed trade, immediately on execution.
 | `product_id` | string | Trading pair (e.g. `BTC-USD`, `SOL-USD`) |
 | `quantity` | float | Number of units traded |
 | `price` | float | Execution price per unit (best ask for buys, best bid for sells) |
-| `total_value` | float | `price * quantity` — total dollar value of the trade |
-| `cash_after` | float | Agent's cash balance after the trade settled |
+| `total_value` | float | `price * quantity` — gross notional of the trade (before fees) |
+| `fee` | float | Taker fee charged. Added on top of notional for buys, deducted from proceeds for sells. `0.0` if fees are disabled |
+| `cash_after` | float | Agent's cash balance after the trade settled (net of fees) |
 | `latency` | float or empty | Seconds between tool invocation and trade execution. Empty if not measured |
 
 ### Example
 
 ```csv
-timestamp,agent_id,action,product_id,quantity,price,total_value,cash_after,latency
-2026-02-26T14:30:52.123456,momentum,buy,BTC-USD,0.5,64200.00,32100.00,67900.00,1.2
-2026-02-26T14:31:10.654321,scalper,sell,SOL-USD,10.0,142.50,1425.00,101425.00,0.8
+timestamp,agent_id,action,product_id,quantity,price,total_value,fee,cash_after,latency
+2026-02-26T14:30:52.123456,momentum,buy,BTC-USD,0.5,64200.00,32100.00,192.60,67707.40,1.2
+2026-02-26T14:31:10.654321,scalper,sell,SOL-USD,10.0,142.50,1425.00,8.55,101416.45,0.8
 ```
 
 ---
@@ -69,17 +70,19 @@ Periodic portfolio snapshots taken at the configured interval. The data is **den
 | `unrealized_pnl` | float | `market_value - cost_basis` — unrealized profit/loss on this position |
 | `portfolio_value` | float | Agent's total portfolio value (cash + all positions at market). Repeated on every row for the agent |
 | `trade_count` | int | Total number of trades the agent has executed to date |
+| `realized_pnl` | float | Cumulative realized P&L from closed quantity, net of both entry and exit fees. Account-level; repeated on every row for the agent |
+| `total_fees_paid` | float | Cumulative taker fees paid across all fills (buys + sells). Account-level; repeated on every row for the agent |
 
 ### Denormalization
 
-An agent holding 3 assets produces 3 rows per snapshot (one per asset), all sharing the same `timestamp`, `agent_id`, `cash`, `portfolio_value`, and `trade_count`. An agent with no positions produces 1 row with `product_id=""` and zero-valued position fields — this preserves the cash and portfolio value in the record.
+An agent holding 3 assets produces 3 rows per snapshot (one per asset), all sharing the same `timestamp`, `agent_id`, `cash`, `portfolio_value`, `trade_count`, `realized_pnl`, and `total_fees_paid`. An agent with no positions produces 1 row with `product_id=""` and zero-valued position fields — this preserves the cash, portfolio value, and account-level totals in the record.
 
 ### Example
 
 ```csv
-timestamp,agent_id,cash,product_id,quantity,cost_basis,market_price,market_value,unrealized_pnl,portfolio_value,trade_count
-2026-02-26T14:35:00.000000,momentum,67900.00,BTC-USD,0.5,32100.00,64500.00,32250.00,150.00,100150.00,1
-2026-02-26T14:35:00.000000,scalper,101425.00,,0.0,0.0,0.0,0.0,0.0,101425.00,1
+timestamp,agent_id,cash,product_id,quantity,cost_basis,market_price,market_value,unrealized_pnl,portfolio_value,trade_count,realized_pnl,total_fees_paid
+2026-02-26T14:35:00.000000,momentum,67707.40,BTC-USD,0.5,32292.60,64500.00,32250.00,-42.60,99957.40,1,0.00,192.60
+2026-02-26T14:35:00.000000,scalper,101416.45,,0.0,0.0,0.0,0.0,0.0,101416.45,2,1416.45,33.55
 ```
 
 ---

--- a/docs/csv-data-recording.md
+++ b/docs/csv-data-recording.md
@@ -47,8 +47,9 @@ One row is written per executed trade, immediately on execution.
 
 ```csv
 timestamp,agent_id,action,product_id,quantity,price,total_value,fee,cash_after,latency
+2026-02-26T14:28:03.111111,scalper,buy,SOL-USD,10.0,140.00,1400.00,8.40,98591.60,0.9
 2026-02-26T14:30:52.123456,momentum,buy,BTC-USD,0.5,64200.00,32100.00,192.60,67707.40,1.2
-2026-02-26T14:31:10.654321,scalper,sell,SOL-USD,10.0,142.50,1425.00,8.55,101416.45,0.8
+2026-02-26T14:31:10.654321,scalper,sell,SOL-USD,10.0,142.50,1425.00,8.55,100008.05,0.8
 ```
 
 ---
@@ -64,10 +65,10 @@ Periodic portfolio snapshots taken at the configured interval. The data is **den
 | `cash` | float | Agent's current cash balance |
 | `product_id` | string | Held asset (e.g. `BTC-USD`). Empty string if the agent has no positions |
 | `quantity` | float | Units held of this asset. `0.0` if no positions |
-| `cost_basis` | float | Total cost paid for this position (average cost method) |
+| `cost_basis` | float | Total cost paid for this position (average cost method), including capitalized buy fees |
 | `market_price` | float | Current market price per unit from the live price book |
 | `market_value` | float | `market_price * quantity` — current dollar value of the position |
-| `unrealized_pnl` | float | `market_value - cost_basis` — unrealized profit/loss on this position |
+| `unrealized_pnl` | float | `market_value - cost_basis` — unrealized profit/loss on this position (net of the capitalized entry fee, since cost basis includes it) |
 | `portfolio_value` | float | Agent's total portfolio value (cash + all positions at market). Repeated on every row for the agent |
 | `trade_count` | int | Total number of trades the agent has executed to date |
 | `realized_pnl` | float | Cumulative realized P&L from closed quantity, net of both entry and exit fees. Account-level; repeated on every row for the agent |
@@ -82,7 +83,7 @@ An agent holding 3 assets produces 3 rows per snapshot (one per asset), all shar
 ```csv
 timestamp,agent_id,cash,product_id,quantity,cost_basis,market_price,market_value,unrealized_pnl,portfolio_value,trade_count,realized_pnl,total_fees_paid
 2026-02-26T14:35:00.000000,momentum,67707.40,BTC-USD,0.5,32292.60,64500.00,32250.00,-42.60,99957.40,1,0.00,192.60
-2026-02-26T14:35:00.000000,scalper,101416.45,,0.0,0.0,0.0,0.0,0.0,101416.45,2,1416.45,33.55
+2026-02-26T14:35:00.000000,scalper,100008.05,,0.0,0.0,0.0,0.0,0.0,100008.05,2,8.05,16.95
 ```
 
 ---

--- a/exchanges/binance.py
+++ b/exchanges/binance.py
@@ -211,9 +211,9 @@ class BinanceKafkaConnector:
         client: Client,
         agent_topic: str,
         symbols: list[str],
+        taker_bps: int,
         min_publish_interval: float = 0.0,
         candle_book: CandleBook | None = None,
-        taker_bps: int = 60,
     ) -> None:
         if not symbols:
             raise ValueError("At least one symbol must be specified")
@@ -520,26 +520,21 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 async def run(args: argparse.Namespace, agent_topic: str = AGENT_INPUT_TOPIC) -> None:
-    # Load symbols + fee rate from config if not provided via CLI
-    symbols = args.symbols
-    taker_bps = 60
-    if symbols is None:
-        from config import load_config
+    # Load the fee rate (and symbols, when not given via CLI) from config.
+    # load_config returns defaults if config.json is absent; if it raises, the file
+    # exists but is invalid — fail loud rather than silently using the wrong fee.
+    from config import load_config
 
-        try:
-            config = load_config(args.config)
-            symbols = config.trading.binance_symbols
-            taker_bps = config.trading.fees.taker_bps
-        except Exception as e:
-            logger.debug("Config not loaded, using defaults: %s", e)
-            symbols = list(DEFAULT_SYMBOLS)
-    else:
-        from config import load_config
-
-        try:
-            taker_bps = load_config(args.config).trading.fees.taker_bps
-        except Exception as e:
-            logger.debug("Config not loaded, using default fee: %s", e)
+    try:
+        config = load_config(args.config)
+    except Exception:
+        logger.error(
+            "Failed to load config from %s; refusing to start with an unknown fee "
+            "rate. Fix the config, or remove it to use defaults.", args.config,
+        )
+        raise
+    symbols = args.symbols or config.trading.binance_symbols or list(DEFAULT_SYMBOLS)
+    taker_bps = config.trading.fees.taker_bps
 
     candle_book = CandleBook(parse_row=parse_binance_candle)
     client = Client.connect(args.bootstrap_servers)

--- a/exchanges/binance.py
+++ b/exchanges/binance.py
@@ -213,6 +213,7 @@ class BinanceKafkaConnector:
         symbols: list[str],
         min_publish_interval: float = 0.0,
         candle_book: CandleBook | None = None,
+        taker_bps: int = 60,
     ) -> None:
         if not symbols:
             raise ValueError("At least one symbol must be specified")
@@ -222,6 +223,7 @@ class BinanceKafkaConnector:
         self._min_interval = min_publish_interval
         self._running = True
         self._candle_book = candle_book
+        self._taker_bps = taker_bps
 
         # Latest ticker per symbol — patched on every incoming message
         self._latest: dict[str, TickerMessage] = {}
@@ -308,11 +310,20 @@ class BinanceKafkaConnector:
         }
         batch_json = json.dumps([t.model_dump(exclude=_exclude) for t in batch])
 
+        fee_line = (
+            f"A taker fee of {self._taker_bps} bps "
+            f"({self._taker_bps / 100:.2f}%) is charged on every fill "
+            "(both buys and sells). Factor this into your sizing and P&L targets — "
+            f"a round-trip costs {2 * self._taker_bps} bps."
+            if self._taker_bps > 0
+            else "Trading is fee-free in this deployment."
+        )
         prompt_parts = [
             "Here is the latest ticker information. You should view your "
             "portfolio first before making any decisions to trade.\n"
             "price = last traded price, best_bid = price you sell at, "
-            "best_ask = price you buy at.\n\n"
+            "best_ask = price you buy at.\n"
+            f"{fee_line}\n\n"
             f"{batch_json}",
         ]
 
@@ -509,17 +520,26 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 async def run(args: argparse.Namespace, agent_topic: str = AGENT_INPUT_TOPIC) -> None:
-    # Load symbols from config if not provided via CLI
+    # Load symbols + fee rate from config if not provided via CLI
     symbols = args.symbols
+    taker_bps = 60
     if symbols is None:
         from config import load_config
 
         try:
             config = load_config(args.config)
             symbols = config.trading.binance_symbols
+            taker_bps = config.trading.fees.taker_bps
         except Exception as e:
-            logger.debug("Config not loaded, using default symbols: %s", e)
+            logger.debug("Config not loaded, using defaults: %s", e)
             symbols = list(DEFAULT_SYMBOLS)
+    else:
+        from config import load_config
+
+        try:
+            taker_bps = load_config(args.config).trading.fees.taker_bps
+        except Exception as e:
+            logger.debug("Config not loaded, using default fee: %s", e)
 
     candle_book = CandleBook(parse_row=parse_binance_candle)
     client = Client.connect(args.bootstrap_servers)
@@ -529,6 +549,7 @@ async def run(args: argparse.Namespace, agent_topic: str = AGENT_INPUT_TOPIC) ->
         symbols=symbols,
         min_publish_interval=args.min_interval,
         candle_book=candle_book,
+        taker_bps=taker_bps,
     )
 
     loop = asyncio.get_running_loop()
@@ -540,6 +561,7 @@ async def run(args: argparse.Namespace, agent_topic: str = AGENT_INPUT_TOPIC) ->
     logger.info("  Broker:      %s", args.bootstrap_servers)
     logger.info("  Symbols:     %s", ", ".join(symbols))
     logger.info("  Min interval: %ss", args.min_interval)
+    logger.info("  Taker fee:   %d bps (%.2f%%)", taker_bps, taker_bps / 100)
 
     await connector.start()
 

--- a/exchanges/binance.py
+++ b/exchanges/binance.py
@@ -25,6 +25,7 @@ import websockets
 
 from calfkit import Client
 
+from arena.fees import FeeModel
 from arena.models import Candle, TIMEFRAMES
 from arena.price_book import CandleBook, PriceBook
 from exchanges import PRICE_TOPIC, TickerMessage
@@ -211,7 +212,7 @@ class BinanceKafkaConnector:
         client: Client,
         agent_topic: str,
         symbols: list[str],
-        taker_bps: int,
+        fee_model: FeeModel,
         min_publish_interval: float = 0.0,
         candle_book: CandleBook | None = None,
     ) -> None:
@@ -223,7 +224,8 @@ class BinanceKafkaConnector:
         self._min_interval = min_publish_interval
         self._running = True
         self._candle_book = candle_book
-        self._taker_bps = taker_bps
+        # Fixed for the connector's lifetime, so build the agent-facing line once.
+        self._fee_disclosure = fee_model.disclosure_prompt()
 
         # Latest ticker per symbol — patched on every incoming message
         self._latest: dict[str, TickerMessage] = {}
@@ -310,20 +312,12 @@ class BinanceKafkaConnector:
         }
         batch_json = json.dumps([t.model_dump(exclude=_exclude) for t in batch])
 
-        fee_line = (
-            f"A taker fee of {self._taker_bps} bps "
-            f"({self._taker_bps / 100:.2f}%) is charged on every fill "
-            "(both buys and sells). Factor this into your sizing and P&L targets — "
-            f"a round-trip costs {2 * self._taker_bps} bps."
-            if self._taker_bps > 0
-            else "Trading is fee-free in this deployment."
-        )
         prompt_parts = [
             "Here is the latest ticker information. You should view your "
             "portfolio first before making any decisions to trade.\n"
             "price = last traded price, best_bid = price you sell at, "
             "best_ask = price you buy at.\n"
-            f"{fee_line}\n\n"
+            f"{self._fee_disclosure}\n\n"
             f"{batch_json}",
         ]
 
@@ -520,21 +514,14 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 async def run(args: argparse.Namespace, agent_topic: str = AGENT_INPUT_TOPIC) -> None:
-    # Load the fee rate (and symbols, when not given via CLI) from config.
-    # load_config returns defaults if config.json is absent; if it raises, the file
-    # exists but is invalid — fail loud rather than silently using the wrong fee.
-    from config import load_config
+    # Load the fee rate (and symbols, when not given via CLI) from config, which
+    # is the single source of truth shared with the tools node. load_config_strict
+    # fails loud if the file exists but is invalid, rather than guessing the fee.
+    from config import load_config_strict
 
-    try:
-        config = load_config(args.config)
-    except Exception:
-        logger.error(
-            "Failed to load config from %s; refusing to start with an unknown fee "
-            "rate. Fix the config, or remove it to use defaults.", args.config,
-        )
-        raise
+    config = load_config_strict(args.config)
     symbols = args.symbols or config.trading.binance_symbols or list(DEFAULT_SYMBOLS)
-    taker_bps = config.trading.fees.taker_bps
+    fee_model = FeeModel(taker_bps=config.trading.fees.taker_bps)
 
     candle_book = CandleBook(parse_row=parse_binance_candle)
     client = Client.connect(args.bootstrap_servers)
@@ -542,9 +529,9 @@ async def run(args: argparse.Namespace, agent_topic: str = AGENT_INPUT_TOPIC) ->
         client=client,
         agent_topic=agent_topic,
         symbols=symbols,
+        fee_model=fee_model,
         min_publish_interval=args.min_interval,
         candle_book=candle_book,
-        taker_bps=taker_bps,
     )
 
     loop = asyncio.get_running_loop()
@@ -556,7 +543,9 @@ async def run(args: argparse.Namespace, agent_topic: str = AGENT_INPUT_TOPIC) ->
     logger.info("  Broker:      %s", args.bootstrap_servers)
     logger.info("  Symbols:     %s", ", ".join(symbols))
     logger.info("  Min interval: %ss", args.min_interval)
-    logger.info("  Taker fee:   %d bps (%.2f%%)", taker_bps, taker_bps / 100)
+    logger.info(
+        "  Taker fee:   %d bps (%.2f%%)", fee_model.taker_bps, fee_model.taker_bps / 100
+    )
 
     await connector.start()
 

--- a/exchanges/coinbase.py
+++ b/exchanges/coinbase.py
@@ -106,9 +106,9 @@ class CoinbaseKafkaConnector:
         client: Client,
         agent_topic: str,
         products: list[str],
+        taker_bps: int,
         min_publish_interval: float = 0.0,
         candle_book: CandleBook | None = None,
-        taker_bps: int = 60,
     ) -> None:
         if not products:
             raise ValueError("At least one product must be specified")
@@ -323,27 +323,21 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 async def run(args: argparse.Namespace, agent_topic: str = AGENT_INPUT_TOPIC) -> None:
-    # Load products + fee rate from config if not provided via CLI
-    products = args.products
-    taker_bps = 60
-    if products is None:
-        from config import load_config
+    # Load the fee rate (and products, when not given via CLI) from config.
+    # load_config returns defaults if config.json is absent; if it raises, the file
+    # exists but is invalid — fail loud rather than silently using the wrong fee.
+    from config import load_config
 
-        try:
-            config = load_config(args.config)
-            products = config.trading.coinbase_products
-            taker_bps = config.trading.fees.taker_bps
-        except Exception as e:
-            logger.debug("Config not loaded, using defaults: %s", e)
-            products = list(DEFAULT_PRODUCTS)
-    else:
-        # Still read fees from config even when products are CLI-overridden
-        from config import load_config
-
-        try:
-            taker_bps = load_config(args.config).trading.fees.taker_bps
-        except Exception as e:
-            logger.debug("Config not loaded, using default fee: %s", e)
+    try:
+        config = load_config(args.config)
+    except Exception:
+        logger.error(
+            "Failed to load config from %s; refusing to start with an unknown fee "
+            "rate. Fix the config, or remove it to use defaults.", args.config,
+        )
+        raise
+    products = args.products or config.trading.coinbase_products or list(DEFAULT_PRODUCTS)
+    taker_bps = config.trading.fees.taker_bps
 
     client = Client.connect(args.bootstrap_servers)
     connector = CoinbaseKafkaConnector(

--- a/exchanges/coinbase.py
+++ b/exchanges/coinbase.py
@@ -108,6 +108,7 @@ class CoinbaseKafkaConnector:
         products: list[str],
         min_publish_interval: float = 0.0,
         candle_book: CandleBook | None = None,
+        taker_bps: int = 60,
     ) -> None:
         if not products:
             raise ValueError("At least one product must be specified")
@@ -117,6 +118,7 @@ class CoinbaseKafkaConnector:
         self._min_interval = min_publish_interval
         self._running = True
         self._candle_book = candle_book
+        self._taker_bps = taker_bps
 
         # Latest ticker per product — patched on every incoming message
         self._latest: dict[str, TickerMessage] = {}
@@ -176,11 +178,20 @@ class CoinbaseKafkaConnector:
         }
         batch_json = json.dumps([t.model_dump(exclude=_exclude) for t in batch])
 
+        fee_line = (
+            f"A taker fee of {self._taker_bps} bps "
+            f"({self._taker_bps / 100:.2f}%) is charged on every fill "
+            "(both buys and sells). Factor this into your sizing and P&L targets — "
+            f"a round-trip costs {2 * self._taker_bps} bps."
+            if self._taker_bps > 0
+            else "Trading is fee-free in this deployment."
+        )
         prompt_parts = [
             "Here is the latest ticker information. You should view your "
             "portfolio first before making any decisions to trade.\n"
             "price = last traded price, best_bid = price you sell at, "
-            "best_ask = price you buy at.\n\n"
+            "best_ask = price you buy at.\n"
+            f"{fee_line}\n\n"
             f"{batch_json}",
         ]
 
@@ -312,17 +323,27 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 async def run(args: argparse.Namespace, agent_topic: str = AGENT_INPUT_TOPIC) -> None:
-    # Load products from config if not provided via CLI
+    # Load products + fee rate from config if not provided via CLI
     products = args.products
+    taker_bps = 60
     if products is None:
         from config import load_config
 
         try:
             config = load_config(args.config)
             products = config.trading.coinbase_products
+            taker_bps = config.trading.fees.taker_bps
         except Exception as e:
-            logger.debug("Config not loaded, using default products: %s", e)
+            logger.debug("Config not loaded, using defaults: %s", e)
             products = list(DEFAULT_PRODUCTS)
+    else:
+        # Still read fees from config even when products are CLI-overridden
+        from config import load_config
+
+        try:
+            taker_bps = load_config(args.config).trading.fees.taker_bps
+        except Exception as e:
+            logger.debug("Config not loaded, using default fee: %s", e)
 
     client = Client.connect(args.bootstrap_servers)
     connector = CoinbaseKafkaConnector(
@@ -330,6 +351,7 @@ async def run(args: argparse.Namespace, agent_topic: str = AGENT_INPUT_TOPIC) ->
         agent_topic=agent_topic,
         products=products,
         min_publish_interval=args.min_interval,
+        taker_bps=taker_bps,
     )
 
     loop = asyncio.get_running_loop()
@@ -341,6 +363,7 @@ async def run(args: argparse.Namespace, agent_topic: str = AGENT_INPUT_TOPIC) ->
     logger.info("  Broker:      %s", args.bootstrap_servers)
     logger.info("  Products:    %s", ", ".join(products))
     logger.info("  Min interval: %ss", args.min_interval)
+    logger.info("  Taker fee:   %d bps (%.2f%%)", taker_bps, taker_bps / 100)
 
     await connector.start()
 

--- a/exchanges/coinbase.py
+++ b/exchanges/coinbase.py
@@ -22,6 +22,7 @@ import websockets
 
 from calfkit import Client
 
+from arena.fees import FeeModel
 from arena.models import Candle, TIMEFRAMES
 from arena.price_book import CandleBook
 from exchanges import PRICE_TOPIC, TickerMessage
@@ -106,7 +107,7 @@ class CoinbaseKafkaConnector:
         client: Client,
         agent_topic: str,
         products: list[str],
-        taker_bps: int,
+        fee_model: FeeModel,
         min_publish_interval: float = 0.0,
         candle_book: CandleBook | None = None,
     ) -> None:
@@ -118,7 +119,8 @@ class CoinbaseKafkaConnector:
         self._min_interval = min_publish_interval
         self._running = True
         self._candle_book = candle_book
-        self._taker_bps = taker_bps
+        # Fixed for the connector's lifetime, so build the agent-facing line once.
+        self._fee_disclosure = fee_model.disclosure_prompt()
 
         # Latest ticker per product — patched on every incoming message
         self._latest: dict[str, TickerMessage] = {}
@@ -178,20 +180,12 @@ class CoinbaseKafkaConnector:
         }
         batch_json = json.dumps([t.model_dump(exclude=_exclude) for t in batch])
 
-        fee_line = (
-            f"A taker fee of {self._taker_bps} bps "
-            f"({self._taker_bps / 100:.2f}%) is charged on every fill "
-            "(both buys and sells). Factor this into your sizing and P&L targets — "
-            f"a round-trip costs {2 * self._taker_bps} bps."
-            if self._taker_bps > 0
-            else "Trading is fee-free in this deployment."
-        )
         prompt_parts = [
             "Here is the latest ticker information. You should view your "
             "portfolio first before making any decisions to trade.\n"
             "price = last traded price, best_bid = price you sell at, "
             "best_ask = price you buy at.\n"
-            f"{fee_line}\n\n"
+            f"{self._fee_disclosure}\n\n"
             f"{batch_json}",
         ]
 
@@ -323,29 +317,22 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 async def run(args: argparse.Namespace, agent_topic: str = AGENT_INPUT_TOPIC) -> None:
-    # Load the fee rate (and products, when not given via CLI) from config.
-    # load_config returns defaults if config.json is absent; if it raises, the file
-    # exists but is invalid — fail loud rather than silently using the wrong fee.
-    from config import load_config
+    # Load the fee rate (and products, when not given via CLI) from config, which
+    # is the single source of truth shared with the tools node. load_config_strict
+    # fails loud if the file exists but is invalid, rather than guessing the fee.
+    from config import load_config_strict
 
-    try:
-        config = load_config(args.config)
-    except Exception:
-        logger.error(
-            "Failed to load config from %s; refusing to start with an unknown fee "
-            "rate. Fix the config, or remove it to use defaults.", args.config,
-        )
-        raise
+    config = load_config_strict(args.config)
     products = args.products or config.trading.coinbase_products or list(DEFAULT_PRODUCTS)
-    taker_bps = config.trading.fees.taker_bps
+    fee_model = FeeModel(taker_bps=config.trading.fees.taker_bps)
 
     client = Client.connect(args.bootstrap_servers)
     connector = CoinbaseKafkaConnector(
         client=client,
         agent_topic=agent_topic,
         products=products,
+        fee_model=fee_model,
         min_publish_interval=args.min_interval,
-        taker_bps=taker_bps,
     )
 
     loop = asyncio.get_running_loop()
@@ -357,7 +344,9 @@ async def run(args: argparse.Namespace, agent_topic: str = AGENT_INPUT_TOPIC) ->
     logger.info("  Broker:      %s", args.bootstrap_servers)
     logger.info("  Products:    %s", ", ".join(products))
     logger.info("  Min interval: %ss", args.min_interval)
-    logger.info("  Taker fee:   %d bps (%.2f%%)", taker_bps, taker_bps / 100)
+    logger.info(
+        "  Taker fee:   %d bps (%.2f%%)", fee_model.taker_bps, fee_model.taker_bps / 100
+    )
 
     await connector.start()
 

--- a/tests/test_arena.py
+++ b/tests/test_arena.py
@@ -356,6 +356,13 @@ def test_fee_model_rejects_out_of_range_bps():
         FeeModel(taker_bps=MAX_TAKER_BPS + 1)
 
 
+def test_fee_model_disclosure_prompt():
+    """The agent-facing disclosure reports the rate and round-trip cost, or fee-free at 0."""
+    line = FeeModel(taker_bps=60).disclosure_prompt()
+    assert "60 bps" in line and "0.60%" in line and "120 bps" in line  # round trip = 2x
+    assert FeeModel(taker_bps=0).disclosure_prompt() == "Trading is fee-free in this deployment."
+
+
 # ── Tests ───────────────────────────────────────────────────────
 
 

--- a/tests/test_arena.py
+++ b/tests/test_arena.py
@@ -13,7 +13,7 @@ from faststream.kafka import TestKafkaBroker
 
 from calfkit import Agent, Client, OpenAIModelClient, Worker
 
-from arena.fees import FeeModel
+from arena.fees import MAX_TAKER_BPS, FeeModel, Fill
 from arena.models import INITIAL_CASH
 from arena.tools import calculator, execute_trade, get_portfolio, price_book, store
 
@@ -231,6 +231,129 @@ def test_realized_pnl_nets_both_fees_on_round_trip():
     assert account.realized_pnl == pytest.approx(proceeds - cost_basis)
     assert account.realized_pnl < 0  # spread + round-trip fees guarantee a loss
     assert "BTC-USD" not in account.positions
+
+
+def test_partial_sell_reduces_basis_proportionally_and_realizes_pnl():
+    """Selling part of a position keeps per-unit cost constant and realizes P&L on the sold portion."""
+    store.set_fee_model(FeeModel(taker_bps=60))
+    agent = "fee_test_partial"
+
+    store.execute_trade(agent, "BTC-USD", 1.0, "buy")
+    account = store.get_or_create(agent)
+    avg_cost = account.avg_cost_per_unit("BTC-USD")  # fee-inclusive
+
+    store.execute_trade(agent, "BTC-USD", 0.4, "sell")
+
+    cash_in = 49990.00 * 0.4 * 0.994  # best_bid notional − sell fee
+    assert account.positions["BTC-USD"] == pytest.approx(0.6)
+    # Per-unit cost is unchanged by a partial sell; only quantity and basis shrink.
+    assert account.avg_cost_per_unit("BTC-USD") == pytest.approx(avg_cost)
+    assert account.cost_basis["BTC-USD"] == pytest.approx(avg_cost * 0.6)
+    assert account.realized_pnl == pytest.approx(cash_in - avg_cost * 0.4)
+
+
+def test_multiple_buys_use_weighted_average_cost_including_fees():
+    """Two buys at different prices blend into a single fee-inclusive weighted-average cost."""
+    store.set_fee_model(FeeModel(taker_bps=60))
+    agent = "fee_test_avg"
+
+    store.execute_trade(agent, "BTC-USD", 0.5, "buy")
+    cost1 = 50010.00 * 0.5 * 1.006  # notional + capitalized fee
+
+    # Raise BTC's price, then buy again. The fixture re-seeds the book each test,
+    # so this mutation does not leak.
+    higher = dict(
+        TEST_PRICES["BTC-USD"], price="60000.00", best_bid="59990.00", best_ask="60010.00"
+    )
+    price_book.update(higher)
+    store.execute_trade(agent, "BTC-USD", 0.5, "buy")
+    cost2 = 60010.00 * 0.5 * 1.006
+
+    account = store.get_or_create(agent)
+    assert account.positions["BTC-USD"] == pytest.approx(1.0)
+    assert account.cost_basis["BTC-USD"] == pytest.approx(cost1 + cost2)
+    assert account.avg_cost_per_unit("BTC-USD") == pytest.approx(cost1 + cost2)
+
+
+def test_realized_pnl_accumulates_across_multiple_closes():
+    """realized_pnl sums P&L across separate closes rather than overwriting."""
+    store.set_fee_model(FeeModel(taker_bps=60))
+    agent = "fee_test_accum"
+
+    store.execute_trade(agent, "BTC-USD", 0.5, "buy")
+    store.execute_trade(agent, "BTC-USD", 0.5, "sell")
+    account = store.get_or_create(agent)
+    first_close = account.realized_pnl
+    assert first_close < 0
+
+    store.execute_trade(agent, "BTC-USD", 0.5, "buy")
+    store.execute_trade(agent, "BTC-USD", 0.5, "sell")
+    assert account.realized_pnl == pytest.approx(2 * first_close)
+
+
+def test_rejected_buy_leaves_account_state_unchanged():
+    """A buy rejected for insufficient cash must not mutate any account state."""
+    store.set_fee_model(FeeModel(taker_bps=60))
+    agent = "fee_test_reject"
+    account = store.get_or_create(agent)
+    account.cash = 100.0  # nowhere near enough for 0.5 BTC
+
+    result = store.execute_trade(agent, "BTC-USD", 0.5, "buy")
+    assert not result.success
+    assert account.cash == 100.0
+    assert account.positions == {}
+    assert account.cost_basis == {}
+    assert account.total_fees_paid == 0.0
+    assert account.realized_pnl == 0.0
+    assert account.trade_count == 0
+
+
+def test_recorder_receives_fee_on_trade():
+    """The taker fee is forwarded to an attached TradeRecorder."""
+    store.set_fee_model(FeeModel(taker_bps=60))
+    agent = "fee_test_recorder"
+    captured: dict[str, float] = {}
+
+    class _FakeRecorder:
+        def record_trade(
+            self, *, agent_id, action, product_id, quantity, price, fee, cash_after, latency
+        ):
+            captured.update(fee=fee, cash_after=cash_after)
+
+    store.attach_recorder(_FakeRecorder())
+    try:
+        store.execute_trade(agent, "BTC-USD", 0.5, "buy")
+    finally:
+        store.attach_recorder(None)  # detach so other tests are unaffected
+
+    assert captured["fee"] == pytest.approx(50010.00 * 0.5 * 0.006)
+
+
+# ── FeeModel unit tests (no account store) ──────────────────────
+
+
+def test_fee_model_unit_behavior():
+    """FeeModel computes taker_rate and fills as pure functions."""
+    fm = FeeModel(taker_bps=60)
+    assert fm.taker_rate == pytest.approx(0.006)
+
+    buy = fm.buy_cost(1000.0)
+    assert isinstance(buy, Fill)
+    assert (buy.cash, buy.fee) == pytest.approx((1006.0, 6.0))
+
+    sell = fm.sell_proceeds(1000.0)
+    assert (sell.cash, sell.fee) == pytest.approx((994.0, 6.0))
+
+    # Zero fee is a pass-through.
+    assert FeeModel(taker_bps=0).buy_cost(1000.0) == (1000.0, 0.0)
+
+
+def test_fee_model_rejects_out_of_range_bps():
+    """taker_bps must lie within [0, MAX_TAKER_BPS]."""
+    with pytest.raises(ValueError):
+        FeeModel(taker_bps=-1)
+    with pytest.raises(ValueError):
+        FeeModel(taker_bps=MAX_TAKER_BPS + 1)
 
 
 # ── Tests ───────────────────────────────────────────────────────

--- a/tests/test_arena.py
+++ b/tests/test_arena.py
@@ -13,6 +13,7 @@ from faststream.kafka import TestKafkaBroker
 
 from calfkit import Agent, Client, OpenAIModelClient, Worker
 
+from arena.fees import FeeModel
 from arena.models import INITIAL_CASH
 from arena.tools import calculator, execute_trade, get_portfolio, price_book, store
 
@@ -62,14 +63,21 @@ TEST_PRICES = {
 
 @pytest.fixture(autouse=True)
 def seed_price_book():
-    """Seed shared PriceBook with test data and reset accounts between tests."""
+    """Seed shared PriceBook with test data and reset accounts between tests.
+
+    Pins the fee model to 0 bps so cash-math assertions below are independent
+    of whatever production default is in effect. Fee application is covered
+    separately by arena/account_store.py unit paths.
+    """
     for data in TEST_PRICES.values():
         price_book.update(data)
     store._accounts.clear()
     store._trade_log.clear()
+    store.set_fee_model(FeeModel(taker_bps=0))
     yield
     store._accounts.clear()
     store._trade_log.clear()
+    store.set_fee_model(FeeModel())
 
 
 @pytest.fixture(scope="session")
@@ -109,6 +117,120 @@ def deploy_client() -> Client:
 def _account():
     """Get the arena agent's account from the shared store."""
     return store.get_or_create(AGENT_NAME)
+
+
+# ── Fee model unit tests (no LLM required) ──────────────────────
+
+
+def test_buy_fee_capitalized_into_cost_basis():
+    """A buy with fees charges notional + fee and rolls the fee into cost basis."""
+    store.set_fee_model(FeeModel(taker_bps=60))
+    agent = "fee_test_buy"
+
+    result = store.execute_trade(agent, "BTC-USD", 0.5, "buy")
+    assert result.success, result.message
+
+    account = store.get_or_create(agent)
+    price = 50010.00  # best_ask
+    notional = price * 0.5
+    expected_fee = notional * 0.006
+    expected_cash_out = notional + expected_fee
+
+    assert account.cash == pytest.approx(INITIAL_CASH - expected_cash_out)
+    assert account.cost_basis["BTC-USD"] == pytest.approx(expected_cash_out)
+
+
+def test_sell_fee_deducted_from_proceeds():
+    """A sell with fees credits notional − fee to cash."""
+    store.set_fee_model(FeeModel(taker_bps=60))
+    agent = "fee_test_sell"
+
+    store.execute_trade(agent, "BTC-USD", 0.5, "buy")
+    account = store.get_or_create(agent)
+    cash_after_buy = account.cash
+
+    result = store.execute_trade(agent, "BTC-USD", 0.5, "sell")
+    assert result.success, result.message
+
+    sell_price = 49990.00  # best_bid
+    sell_notional = sell_price * 0.5
+    sell_fee = sell_notional * 0.006
+    expected_proceeds = sell_notional - sell_fee
+
+    assert account.cash == pytest.approx(cash_after_buy + expected_proceeds)
+    # Fully closed position — round-trip in a flat market always loses both fees
+    assert "BTC-USD" not in account.positions
+
+
+def test_zero_fee_matches_notional():
+    """taker_bps=0 recovers the fee-free behavior."""
+    store.set_fee_model(FeeModel(taker_bps=0))
+    agent = "fee_test_zero"
+
+    store.execute_trade(agent, "BTC-USD", 0.5, "buy")
+    account = store.get_or_create(agent)
+
+    assert account.cash == pytest.approx(INITIAL_CASH - 50010.00 * 0.5)
+    assert account.cost_basis["BTC-USD"] == pytest.approx(50010.00 * 0.5)
+
+
+def test_buy_fee_blocks_when_cash_insufficient_for_fee():
+    """A buy that fits notional-only but not notional+fee is rejected."""
+    store.set_fee_model(FeeModel(taker_bps=60))
+    agent = "fee_test_insufficient"
+    account = store.get_or_create(agent)
+    # Just enough cash for notional, not for the 0.6% fee on top.
+    account.cash = 50010.00 * 0.5
+
+    result = store.execute_trade(agent, "BTC-USD", 0.5, "buy")
+    assert not result.success
+    assert "Insufficient cash" in result.message
+
+
+def test_total_fees_paid_accumulates_buy_and_sell():
+    """total_fees_paid sums the taker fee from every fill (buys and sells)."""
+    store.set_fee_model(FeeModel(taker_bps=60))
+    agent = "fee_test_total"
+
+    store.execute_trade(agent, "BTC-USD", 0.5, "buy")
+    store.execute_trade(agent, "BTC-USD", 0.5, "sell")
+    account = store.get_or_create(agent)
+
+    buy_fee = 50010.00 * 0.5 * 0.006
+    sell_fee = 49990.00 * 0.5 * 0.006
+    assert account.total_fees_paid == pytest.approx(buy_fee + sell_fee)
+
+
+def test_realized_pnl_zero_until_position_closed():
+    """Opening a position accrues fees but realizes no P&L until a sell."""
+    store.set_fee_model(FeeModel(taker_bps=60))
+    agent = "fee_test_open_only"
+
+    store.execute_trade(agent, "BTC-USD", 0.5, "buy")
+    account = store.get_or_create(agent)
+
+    assert account.realized_pnl == 0.0
+    assert account.total_fees_paid == pytest.approx(50010.00 * 0.5 * 0.006)
+
+
+def test_realized_pnl_nets_both_fees_on_round_trip():
+    """A flat-market round trip realizes a loss equal to the spread plus both fees.
+
+    Buy fees enter realized P&L through the capitalized cost basis; sell fees are
+    deducted from proceeds — so the figure already reflects the full round-trip cost.
+    """
+    store.set_fee_model(FeeModel(taker_bps=60))
+    agent = "fee_test_realized"
+
+    store.execute_trade(agent, "BTC-USD", 0.5, "buy")
+    store.execute_trade(agent, "BTC-USD", 0.5, "sell")
+    account = store.get_or_create(agent)
+
+    cost_basis = 50010.00 * 0.5 * 1.006  # notional + capitalized buy fee
+    proceeds = 49990.00 * 0.5 * 0.994  # notional − sell fee
+    assert account.realized_pnl == pytest.approx(proceeds - cost_basis)
+    assert account.realized_pnl < 0  # spread + round-trip fees guarantee a loss
+    assert "BTC-USD" not in account.positions
 
 
 # ── Tests ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds a realistic **taker-fee model** to the trading arena so simulated fills reflect real trading costs, following the standard percentage-of-notional convention used by Backtrader, Backtesting.py, and QuantConnect LEAN.

### Fee model (`arena/fees.py`)
- `FeeModel(taker_bps)` — **taker-only**, justified because every fill crosses the spread (buys at `best_ask`, sells at `best_bid`); the spread is already a separate, modeled cost.
- **Buys** charge `notional + fee` and **capitalize the fee into cost basis**; **sells** credit `notional − fee` — the standard (and tax-standard) cost-basis convention. The insufficient-cash check uses the fee-inclusive total.
- `taker_bps` is validated to `[0, MAX_TAKER_BPS]` (1000 bps) and kept an `int` — every documented venue preset is a whole number of bps; the rationale is documented in the module.
- Defaults: `60` bps = Coinbase Advanced Trade base tier; `10` = Binance VIP 0; `40` = Kraken Pro; `0` disables.

### Single source of truth
- `trading.fees.taker_bps` in `config.json` is the only place the fee is set (no CLI override). It is read via `config.load_config_strict()` by **both** the tools node (which *charges* the fee) and the price-feed connectors (which *advertise* it to agents via `FeeModel.disclosure_prompt()`), so the charged and advertised fees cannot diverge.
- **Fail-loud:** a missing config still falls back to defaults, but an *invalid* one (bad JSON, unset `${ENV_VAR}`, out-of-range value) logs at ERROR and aborts rather than silently trading at the wrong rate.
- Changing the fee requires restarting **both** processes (each reads config once at startup) — documented.

### Tracking (it's an arena)
- `AgentAccount` gains `total_fees_paid` and `realized_pnl` (realized P&L nets **both** entry and exit fees — buy fee via the capitalized basis, sell fee from proceeds).
- Surfaced on the dashboard leaderboard cards and in `snapshots_*.csv` (`realized_pnl`, `total_fees_paid` columns).

### Docs
- README, `docs/CLI_REFERENCE.md`, `docs/csv-data-recording.md`, `config.example.json`, `config.schema.json` updated.

## Testing
- **15 fee/unit tests pass** (21 collected): capitalization into basis, proceeds deduction, zero-fee parity, insufficient-cash-for-fee, cumulative-fee accumulation, fee-inclusive realized P&L, partial-sell proportional basis, multi-buy weighted-average cost, realized-P&L accumulation across closes, rejected-buy-leaves-state-unchanged, recorder-receives-fee, and `FeeModel` unit tests (rate, fills, out-of-range rejection, disclosure).
- LLM integration tests unchanged (autouse fixture pins fees to 0).

## Review hardening
This PR was reviewed by a multi-agent pass and then a `/simplify` pass:
- **Review fixes:** fail-loud config handling; a single `DEFAULT_TAKER_BPS`/`MAX_TAKER_BPS` constant (no duplicated `60`); `Fill` and `TradeLogEntry` NamedTuples replacing positional tuples; doc-example consistency fixes.
- **Simplification:** `FeeModel` owns the agent-facing disclosure string (built once at connector init, not per ticker batch); connectors hold a `FeeModel` rather than a raw int; the fail-loud loader is one shared helper.

## Notes
- Default rates verified against current Coinbase / Binance / Kraken published schedules.
- Out of scope (by decision): fractional-bps rates such as Binance's 7.5 bps BNB discount (`int` is the stronger invariant, documented); a per-trade fee column in the dashboard trade log; an integration test at a non-zero fee.