### PR TITLE
docs: redraw architecture diagram around the connector proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,30 +23,37 @@ If you find this project interesting or useful, please consider:
 ## Architecture
 
 ```
-                         ┌──────────────────┐
-                         │    Agent(s)      │
-                         │ (LLM Inference)  │
-                         └──────────────────┘
-                                  ▲
-                                  │
-                                  ▼
-Live Market          ┌────────────────┐
-Data Stream  ──▶     │  Kafka Broker  │
-                     └────────────────┘
-                                  ▲
-                                  │
-                                  ▼
-                       ┌────────────────────────┐
-                       │ Tools & Dashboard      │
-                       │ (Trading Tools + UI)   │
-                       └────────────────────────┘
+                           Live market data
+                (Coinbase / Binance — WebSocket + REST)
+                                   │
+                                   ▼
+            ┌─────────────────────────────────────────────┐
+            │              Exchange connector             │
+            │           (live-market-data proxy)          │
+            └─────────────────────────────────────────────┘
+                  │                                │
+             live prices                   market snapshots
+                  ▼                                ▼
+   ┌────────────────────────────┐   ┌────────────────────────────┐
+   │     Tools & Dashboard      │   │     Agent process  × N     │
+   │   paper wallets · tools    │◀─▶│  embedded LLM + strategy   │
+   │   live dashboard (Rich)    │   │     agent 1 … agent N      │
+   └────────────────────────────┘   └────────────────────────────┘
+                     tool calls  ⇄  tool results
 ```
 
-Each box (or node) is an independent process communicating with eachother. Each node can run on the same machine, on separate servers, or across different cloud regions.
+Each box is an independent process and can run anywhere — same machine, separate
+servers, or different cloud regions. A single **exchange connector** holds the only
+link to the market and acts as a proxy: it streams live prices to the Tools &
+Dashboard process (which marks and fills trades) and market snapshots to every Agent
+process. Agents and Tools then talk directly — agents issue tool calls and receive
+results. Every arrow rides an underlying broker (Kafka): the communication mesh each
+process plugs into, not a node in the topology.
 
 Key design points:
+- **Connector as market-data proxy**: One process owns the exchange link and fans the feed out, so neither agents nor tools touch the exchange directly.
 - **Per-agent model selection**: Each agent embeds its own model client, so different agents can use different LLMs with different providers.
-- **Fan-out via consumer groups**: Every agent independently receives every market data update, with no replicated work.
+- **Fan-out**: Every agent independently receives every market-data update, with no replicated work.
 - **Shared tools via ToolContext**: A single deployed set of trading tools serves all agents — each tool resolves the calling agent's identity at runtime.
 - **Dynamic agent accounts**: Agents appear on the dashboard automatically on their first trade — no pre-registration needed.
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ If you find this project interesting or useful, please consider:
                      tool calls  ⇄  tool results
 ```
 
-Each box is an independent process and can run anywhere — same machine, separate
-servers, or different cloud regions. A single **exchange connector** holds the only
-link to the market and acts as a proxy: it streams live prices to the Tools &
-Dashboard process (which marks and fills trades) and market snapshots to every Agent
-process. Agents and Tools then talk directly — agents issue tool calls and receive
-results. Every arrow rides an underlying broker (Kafka): the communication mesh each
-process plugs into, not a node in the topology.
+A single **exchange connector** turns the live market into a continuous event stream
+that the agents and the Tools process consume in realtime. Each **agent** reacts on
+every update — reasoning over the latest prices and candlesticks to decide whether to
+buy, sell, or hold. The **Tools & Dashboard** process consumes the same stream to keep
+its price book current, so trades fill and the dashboard marks against up-to-the-moment
+prices. Agents act by calling tools (trade, portfolio, calculator), forming a tight
+loop: market event → decision → trade → updated state.
 
 Key design points:
 - **Connector as market-data proxy**: One process owns the exchange link and fans the feed out, so neither agents nor tools touch the exchange directly.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # The Agents Trading Arena 🤖 🤺
 
+[![CI](https://img.shields.io/github/actions/workflow/status/ryan-yuuu/crypto-trading-arena/ci.yml?branch=main&style=flat-square&logo=github&label=CI)](https://github.com/ryan-yuuu/crypto-trading-arena/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue?style=flat-square)](LICENSE)
 [![Discord](https://img.shields.io/discord/1478593215555960902?style=flat-square&logo=discord&label=Discord)](https://discord.gg/Ch3U4VV7Nj)
 
 A multi-agent crypto trading arena where AI agents compete against each other, trading with live crypto market data from Coinbase or Binance. Each agent consumes a livestream of ticker data and standard candlestick charts, has access to its portfolio and calculator, and executes trades autonomously. This is all built with [Calfkit](https://github.com/calf-ai/calfkit-sdk) agents, namely for their multi-agent orchestration and realtime data streaming functionality.


### PR DESCRIPTION
## Summary

Redraws the README architecture diagram to better reflect the real topology.

- The **exchange connector** is shown as a market-data **proxy**: live market data
  streams in, and the connector fans out **live prices** to the Tools & Dashboard
  process and **market snapshots** to the N agent processes.
- **Agents and the Tools process communicate directly** (`◀─▶` — tool calls ⇄ results).
- The **broker is no longer a node** in the diagram; it's described as the underlying
  communication mesh every process plugs into.

Also tightens the accompanying prose to match.

Docs-only; no code changes. Independent of #16 (the test-suite/CI PR).
