### PR TITLE
ci: run unit tests only on the floor Python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,19 +32,16 @@ jobs:
         run: uv run ruff check .
 
   unit:
-    name: Unit tests (py${{ matrix.python-version }})
+    name: Unit tests (py3.10)
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
-          python-version: ${{ matrix.python-version }}
+          # Floor of requires-python (>=3.10); a green floor implies newer versions.
+          python-version: "3.10"
       - name: Install dependencies
         run: uv sync --frozen
       - name: Run non-LLM, non-broker tests


### PR DESCRIPTION
## Summary

Drops the Python version matrix from the `unit` CI job and pins it to **3.10**, the
floor of `requires-python` (`>=3.10`).

- Before: unit tests ran on 3.10, 3.11, and 3.12.
- After: unit tests run only on 3.10.

A green floor version implies the newer interpreters work, so the extra matrix legs
were redundant CI cost. The `lint` and `broker` jobs are unchanged.
